### PR TITLE
Hotfixes/ensure reference token exchange is not executed for jwts

### DIFF
--- a/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
+++ b/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
+++ b/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="IdentityModel" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
+++ b/Clawrenceks.Middleware.ReferenceTokenExchange/Clawrenceks.Middleware.ReferenceTokenExchange.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="IdentityModel" Version="4.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated the Reference Token Exchange middleware so that it does not attempt token exchange when the token parsed from the request is a JWT